### PR TITLE
Oppgraderer Distroless til nodejs20-debian12@sha256:f912a759

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12@sha256:2818fb8cdc25894d9c6b6e6bf72b4033d949f5d6d65173a6d7aeec0266f03037
+FROM gcr.io/distroless/nodejs20-debian12@sha256:f912a7599e5338df6527a669def29bddc9469fdac9ab22c4cc9282c1b64c868b
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli