### PR TITLE
Oppgraderer Distroless til nodejs20-debian12@sha256:55fcbc1b

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12@sha256:a6c0e95f6f70fb21586757a846d8b8d287609f2414bcc2399895adb055768648
+FROM gcr.io/distroless/nodejs20-debian12@sha256:55fcbc1b781606f4aa3587d3ee174a8acfc975b02a3ea252cef282895ac362d5
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli