### PR TITLE
Fjern next.config.js fra Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM gcr.io/distroless/nodejs24-debian13@sha256:10e262383ceb3a2a5f6f5ceaca5ecebe
 
 ENV NODE_ENV production
 
-COPY /next.config.js ./
 COPY /.next ./.next
 COPY /node_modules ./node_modules
 COPY /public ./public


### PR DESCRIPTION
Følger opp #1122 — `next.config.js` ble slettet, men `Dockerfile` hadde fortsatt en `COPY` av filen som brøt CI-bygget.

## Hvorfor ble next.config.js slettet?

`next.config.ts` er konfigurasjonsfilen for Next.js-applikasjonen. Den er valgfri — Next.js fungerer fint uten den, og bør kun opprettes når du faktisk trenger å konfigurere noe.

Filen brukes typisk til å sette opp HTTP-sikkerhetshoder (som beskytter mot clickjacking og cross-site scripting), definere omdirigeringer fra gamle URL-er, styre hvordan applikasjonen bygges og pakkes for produksjon, eller aktivere eksperimentelle Next.js-funksjoner.

Filen ble slettet fordi den ikke inneholdt noe meningsfullt — bare et tomt objekt. Dersom vi senere ønsker å legge til f.eks. `output: 'standalone'` for et lettere Docker-image, eller sikkerhetshoder, er det riktig tidspunkt å gjenopprette den som `next.config.ts`.