### PR TITLE
Fjern ubrukt @next/mdx og oppdater eslint-config-next til 15.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
                 "@navikt/ds-tailwind": "7.38.0",
                 "@navikt/ds-tokens": "^7.37.0",
                 "@navikt/next-logger": "^4.5.1",
-                "@next/mdx": "^14.2.15",
                 "@types/node": "20.14.10",
                 "@types/react": "18.3.12",
                 "@types/react-dom": "18.3.1",
@@ -32,7 +31,7 @@
             "devDependencies": {
                 "@navikt/eslint-config-teamsykmelding": "^7.1.0",
                 "eslint": "8.57.1",
-                "eslint-config-next": "14.2.15"
+                "eslint-config-next": "15.5.18"
             },
             "engines": {
                 "node": "24"
@@ -840,19 +839,6 @@
                 "typescript": ">=4"
             }
         },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/eslint-plugin-react-hooks": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
-            "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-            }
-        },
         "node_modules/@navikt/next-logger": {
             "version": "4.5.1",
             "resolved": "https://npm.pkg.github.com/download/@navikt/next-logger/4.5.1/e8c32873a7931396b0871c77b94673cbfb12d376",
@@ -894,32 +880,43 @@
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.15.tgz",
-            "integrity": "sha512-pKU0iqKRBlFB/ocOI1Ip2CkKePZpYpnw5bEItEkuZ/Nr9FQP1+p7VDWr4VfOdff4i9bFmrOaeaU1bFEyAcxiMQ==",
+            "version": "15.5.18",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.18.tgz",
+            "integrity": "sha512-w4MYq8M26a8PNrfto0JosLf5/3ssln1rsyP96g2DkC8uFVymStM5DLSz5ElxxrPRg2XnTMnFo3kREFlhYvxhWw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "glob": "10.3.10"
+                "fast-glob": "3.3.1"
             }
         },
-        "node_modules/@next/mdx": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-14.2.15.tgz",
-            "integrity": "sha512-OQWxKY5jWtHqPXdN3s5mj/LsD57pxt8CQsY4VQtTfQdQn6rNPd1bjN+kpbtezXdjgrKhvTJAb1yv1XGvzlh0uw==",
+        "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "source-map": "^0.7.0"
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.4"
             },
-            "peerDependencies": {
-                "@mdx-js/loader": ">=0.15.0",
-                "@mdx-js/react": ">=0.15.0"
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
             },
-            "peerDependenciesMeta": {
-                "@mdx-js/loader": {
-                    "optional": true
-                },
-                "@mdx-js/react": {
-                    "optional": true
-                }
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
@@ -1507,13 +1504,13 @@
             "license": "Python-2.0"
         },
         "node_modules/aria-query": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-            "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
             "dev": true,
             "license": "Apache-2.0",
-            "dependencies": {
-                "deep-equal": "^2.0.5"
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/array-buffer-byte-length": {
@@ -1754,9 +1751,9 @@
             }
         },
         "node_modules/axe-core": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
-            "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+            "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
             "dev": true,
             "license": "MPL-2.0",
             "engines": {
@@ -1764,13 +1761,13 @@
             }
         },
         "node_modules/axobject-query": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
-            "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+            "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "dependencies": {
-                "deep-equal": "^2.0.5"
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/backoff": {
@@ -2188,39 +2185,6 @@
                 }
             }
         },
-        "node_modules/deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
-                "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2438,27 +2402,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/es-iterator-helpers": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.0.tgz",
@@ -2620,24 +2563,25 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.15.tgz",
-            "integrity": "sha512-mKg+NC/8a4JKLZRIOBplxXNdStgxy7lzWuedUaCc8tev+Al9mwDUTujQH6W6qXDH9kycWiVo28tADWGvpBsZcQ==",
+            "version": "15.5.18",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.18.tgz",
+            "integrity": "sha512-HuoJU6uUPD00eyiud78IBnT4HLhztFj2V+ild2Uon5ZUrYZKe0Olu2QRD99e9IgL4/H1eg5Onka3BsfRW2U0Xw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "14.2.15",
-                "@rushstack/eslint-patch": "^1.3.3",
+                "@next/eslint-plugin-next": "15.5.18",
+                "@rushstack/eslint-patch": "^1.10.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
-                "eslint-plugin-import": "^2.28.1",
-                "eslint-plugin-jsx-a11y": "^6.7.1",
-                "eslint-plugin-react": "^7.33.2",
-                "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+                "eslint-plugin-import": "^2.31.0",
+                "eslint-plugin-jsx-a11y": "^6.10.0",
+                "eslint-plugin-react": "^7.37.0",
+                "eslint-plugin-react-hooks": "^5.0.0"
             },
             "peerDependencies": {
-                "eslint": "^7.23.0 || ^8.0.0",
+                "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
                 "typescript": ">=3.3.1"
             },
             "peerDependenciesMeta": {
@@ -2827,40 +2771,39 @@
             }
         },
         "node_modules/eslint-plugin-jsx-a11y": {
-            "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.9.0.tgz",
-            "integrity": "sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+            "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "aria-query": "~5.1.3",
+                "aria-query": "^5.3.2",
                 "array-includes": "^3.1.8",
                 "array.prototype.flatmap": "^1.3.2",
                 "ast-types-flow": "^0.0.8",
-                "axe-core": "^4.9.1",
-                "axobject-query": "~3.1.1",
+                "axe-core": "^4.10.0",
+                "axobject-query": "^4.1.0",
                 "damerau-levenshtein": "^1.0.8",
                 "emoji-regex": "^9.2.2",
-                "es-iterator-helpers": "^1.0.19",
                 "hasown": "^2.0.2",
                 "jsx-ast-utils": "^3.3.5",
                 "language-tags": "^1.0.9",
                 "minimatch": "^3.1.2",
                 "object.fromentries": "^2.0.8",
                 "safe-regex-test": "^1.0.3",
-                "string.prototype.includes": "^2.0.0"
+                "string.prototype.includes": "^2.0.1"
             },
             "engines": {
                 "node": ">=4.0"
             },
             "peerDependencies": {
-                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
             }
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2946,16 +2889,16 @@
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-            "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+            "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
             "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
@@ -3838,23 +3781,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-array-buffer": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
@@ -4734,23 +4660,6 @@
             "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5929,15 +5838,6 @@
                 "atomic-sleep": "^1.0.0"
             }
         },
-        "node_modules/source-map": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5953,19 +5853,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">= 10.x"
-            }
-        },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-            "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "internal-slot": "^1.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/string_decoder": {
@@ -6044,14 +5931,18 @@
             }
         },
         "node_modules/string.prototype.includes": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.0.tgz",
-            "integrity": "sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+            "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/string.prototype.matchall": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "@navikt/ds-tailwind": "7.38.0",
         "@navikt/ds-tokens": "^7.37.0",
         "@navikt/next-logger": "^4.5.1",
-        "@next/mdx": "^14.2.15",
         "@types/node": "20.14.10",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
@@ -41,7 +40,7 @@
     "devDependencies": {
         "@navikt/eslint-config-teamsykmelding": "^7.1.0",
         "eslint": "8.57.1",
-        "eslint-config-next": "14.2.15"
+        "eslint-config-next": "15.5.18"
     },
     "eslintConfig": {
         "extends": [


### PR DESCRIPTION
## Hva
- Fjerner `@next/mdx` som aldri har vært i bruk (ingen .mdx-filer, ingen `withMDX`)
- Oppdaterer `eslint-config-next` fra `14.2.15` til `15.5.18` for å matche `next`-versjonen

## Hvorfor
`eslint-config-next` bør alltid matche Next.js-versjonen — versjonsmismatch kan gi falske lint-advarsler. `@next/mdx` er en tung pakke som ikke brukes og øker angrepsflaten unødvendig.