### PR TITLE
fix: legg til WORKDIR og fjern fetch revalidate for å fikse tom TV-skjerm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/distroless/nodejs24-debian13@sha256:10e262383ceb3a2a5f6f5ceaca5ecebe74951eff21868a055589676eec3a8001
 
+WORKDIR /app
+
 ENV NODE_ENV production
 
 COPY /.next ./.next

--- a/src/fetching/flexjarFetching.ts
+++ b/src/fetching/flexjarFetching.ts
@@ -30,7 +30,6 @@ export async function hentFlexjarFeedbacks(): Promise<Feedback[]> {
     }
 
     const response = await fetch(`http://flexjar-backend/api/v1/infoskjerm`, {
-        next: { revalidate: 300 },
         headers: {
             Authorization: `Bearer ${token.token}`,
         },


### PR DESCRIPTION
## Hva
Fikser «Det er ingen tilbakemeldinger» i dev/prod.

## Rotårsak
Ingen `WORKDIR` i Dockerfile → Next.js kjørte fra `/` (rotmappe).

`{ next: { revalidate: 300 } }` forsøkte å skrive til `/.next/cache/fetch-cache` → `ENOENT` → fetch kastet feil → tom feedbacks-liste.

## Endringer

| Fil | Endring |
|-----|---------|
| `Dockerfile` | `WORKDIR /app` lagt til — Nav-standard (ref. meroppfolging-frontend) |
| `flexjarFetching.ts` | Fjernet `{ next: { revalidate: 300 } }` — plain `fetch` er Next.js 15-standard (uncached by default). `router.refresh()` hvert 5. min håndterer allerede oppdatering. |

## Testing
Deploy til dev og verifiser at feedbacks vises på skjermen.